### PR TITLE
Update Nginx config example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Or for Nginx you can add the following to your virtual host setup:
 ```
 location /assets {
     if (!-e $request_filename) {
-        rewrite ^/(.+)\.([0-9a-z]{32})\.(js|css)$ /$1.$3 break;
+        rewrite "^/(.+)\.([0-9a-z]{32})\.(js|css)$" /$1.$3 break;
     }
 }
 ```


### PR DESCRIPTION
Utilizing curly braces "{ }" in rewrite rules causes nginx to think that the location block has been closed (prematurely). This results in a `directive "rewrite" is not terminated by ";"` error

Encasing the rewrite regex in quotes fixes this issue.
