### PR TITLE
Add argument to return the asset url.

### DIFF
--- a/fingerprint.php
+++ b/fingerprint.php
@@ -26,8 +26,8 @@ class CSS extends \Kirby\Component\CSS {
    * @param null|string $media
    * @return string
    */
-    
-  public function tag($url, $media = null) {
+
+  public function tag($url, $media = null, $path = false) {
 
     if(is_array($url)) {
       $css = array();
@@ -58,11 +58,16 @@ class CSS extends \Kirby\Component\CSS {
       $url = ($dirname === '.') ? $filename : $dirname . '/' . $filename;
     }
 
-    return html::tag('link', null, array(
-      'rel'   => 'stylesheet',
-      'href'  => url($url),
-      'media' => $media
-    ));
+    if($path === true) {
+      return url($url);
+    }
+    else {
+      return html::tag('link', null, array(
+        'rel'   => 'stylesheet',
+        'href'  => url($url),
+        'media' => $media
+      ));
+    }
 
   }
 }
@@ -77,7 +82,7 @@ class JS extends \Kirby\Component\JS {
    * @return string
    */
 
-  public function tag($src, $async = false) {
+  public function tag($src, $async = false, $path = false) {
 
     if(is_array($src)) {
       $js = array();
@@ -108,10 +113,15 @@ class JS extends \Kirby\Component\JS {
       $src = ($dirname === '.') ? $filename : $dirname . '/' . $filename;
     }
 
-    return html::tag('script', '', array(
-      'src'   => url($src),
-      'async' => $async
-    ));
+    if($path === true) {
+      return url($src);
+    }
+    else {
+      return html::tag('script', '', array(
+        'src'   => url($src),
+        'async' => $async
+      ));
+    }
 
   }
 }

--- a/kirby-fingerprint.php
+++ b/kirby-fingerprint.php
@@ -13,7 +13,7 @@ use c;
 use f;
 use HTML;
 
-if ( ! c::get('fingerprint')) {
+if ( ! c::get('plugin.fingerprint')) {
     return;
 }
 

--- a/kirby-fingerprint.php
+++ b/kirby-fingerprint.php
@@ -23,11 +23,12 @@ class CSS extends \Kirby\Component\CSS {
    * Builds the html link tag for the given css file
    *
    * @param string $url
+   * @param boolean $path
    * @param null|string $media
    * @return string
    */
 
-  public function tag($url, $media = null, $path = false) {
+  public function tag($url, $path = false, $media = null) {
 
     if(is_array($url)) {
       $css = array();
@@ -78,11 +79,12 @@ class JS extends \Kirby\Component\JS {
    * Builds the html script tag for the given js file
    *
    * @param string $src
+   * @param boolean path
    * @param boolean async
    * @return string
    */
 
-  public function tag($src, $async = false, $path = false) {
+  public function tag($src, $path = false, $async = false) {
 
     if(is_array($src)) {
       $js = array();


### PR DESCRIPTION
I like the way how this plugin adds fingerprints, but in some cases i'd like to just return the css or js file url. For example in anynchronously loading stylesheets after displaying critical css.